### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol (MCP) server for interacting with Wikimedia APIs. Access Wikipedia and other Wikimedia project content programmatically with natural language queries.
 
+<a href="https://glama.ai/mcp/servers/l6ihu97mw7"><img width="380" height="200" src="https://glama.ai/mcp/servers/l6ihu97mw7/badge" alt="Wikimedia Server MCP server" /></a>
+
 ## Features
 
 - **Search Content**: Full-text search across Wikimedia page content


### PR DESCRIPTION
This PR adds a badge for the [Wikimedia MCP Server](https://glama.ai/mcp/servers/l6ihu97mw7) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/l6ihu97mw7"><img width="380" height="200" src="https://glama.ai/mcp/servers/l6ihu97mw7/badge" alt="Wikimedia Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.