### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Wikimedia MCP Server
 
+[![smithery badge](https://smithery.ai/badge/wikimedia)](https://smithery.ai/protocol/wikimedia)
+
 A Model Context Protocol (MCP) server for interacting with Wikimedia APIs. Access Wikipedia and other Wikimedia project content programmatically with natural language queries.
 
 ## Features
@@ -67,6 +69,14 @@ C:\Users\<username>\AppData\Roaming\Claude\claude_desktop_config.json
     }
   }
 }
+```
+
+### Installing via Smithery
+
+To install Wikimedia for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/wikimedia):
+
+```bash
+npx @smithery/cli install wikimedia --client claude
 ```
 
 ## Tools


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Wikimedia for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/protocol/wikimedia

Let me know if any tweaks have to be made!